### PR TITLE
Restore site description to main page

### DIFF
--- a/themes/cards/layouts/_default/list.html
+++ b/themes/cards/layouts/_default/list.html
@@ -2,7 +2,11 @@
 
 <div class="home">
  
-  
+    <div class = "container text-center">
+      {{ .Site.Params.description }}
+    </div>
+
+
     <div class="row pack">
 
         {{ $paginator := .Paginate (where .Site.RegularPages "Section" "posts") }}


### PR DESCRIPTION
This was removed by mistake when upgrading the theme.